### PR TITLE
Fixed .reuse/dep5 syntax

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: sap-customer-data-cloud-toolkit
 Source: https://github.com/SAP/sap-customer-data-cloud-toolkit.git
-
 Disclaimer: The code in this project may include calls to APIs ("API Calls") of
  SAP or third-party products or services developed outside of this project
  ("External Products").


### PR DESCRIPTION
The newline between Source and Disclaimer caused a syntax error in the file. It was found in local testing with `docker run --rm --volume $(pwd):/data fsfe/reuse lint`.

Results before the change:
```
reuse.project - ERROR - .reuse/dep5 has syntax errors
...
# SUMMARY

* Bad licenses:
* Deprecated licenses:
* Licenses without file extension:
* Missing licenses:
* Unused licenses: Apache-2.0
* Used licenses:
* Read errors: 0
* Files with copyright information: 289 / 332
* Files with license information: 0 / 332
```

After the change:
```
❯ docker run --rm --volume $(pwd):/data fsfe/reuse lint
# SUMMARY

* Bad licenses:
* Deprecated licenses:
* Licenses without file extension:
* Missing licenses:
* Unused licenses:
* Used licenses: Apache-2.0
* Read errors: 0
* Files with copyright information: 332 / 332
* Files with license information: 332 / 332

Congratulations! Your project is compliant with version 3.0 of the REUSE Specification :-)
```